### PR TITLE
updated route name length το 3 times the default, to cope with Ingress Controller problems

### DIFF
--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -549,7 +549,11 @@ _M.route = {
             minItems = 1,
             uniqueItems = true,
         },
-        name = rule_name_def,
+        name = {
+            type = "string",
+            maxLength = rule_name_def.maxLength * 3,
+            minLength = rule_name_def.minLength,
+        },
         desc = desc_def,
         priority = {type = "integer", default = 0},
 


### PR DESCRIPTION
## Description

Fixes #11821

## What it does.
It makes the route name accept a name length that is 3 times the default one. That is because in the Ingress Controller, the route name is actually automatically given by concatenating the namespace name + other factors, therefore.

Question:
- Is this better to be a static number (like 600, without depending on the default rule)?
